### PR TITLE
fix: newline excessively escaped

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ function escapeForJson(str) {
         .replace(/”/g, '\\"')    // Escape right double quotation mark
         .replace(/‘/g, "\\'")    // Escape left single quotation mark
         .replace(/’/g, "\\'")    // Escape right single quotation mark
-        .replace(/\n/g, '\\n')   // Escape newlines
         .replace(/\r/g, '\\r');  // Escape carriage returns
 }
 Toolkit.run(async tools => {


### PR DESCRIPTION
Newline shouldn't have been double escaped as it is valid JSON content. According to the last two releases on SPC, here's the body payload that comes in to the website:
![image](https://github.com/user-attachments/assets/5f49b61f-2061-4f87-aab6-58bcb9a2c330)

This means that the newlines are treated as `\n` in plain chars instead of the actual new line char, yielding them to be treated as such in the body of the changelog when saved on the store. 